### PR TITLE
Fixes image link and footer width

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css">
     <style>
 
-      html, body, footer {
+      html, body {
         width: 100%;
         height: 100%;
       }
@@ -59,7 +59,34 @@
       .nav-masthead .active {
        color: rgb(9, 8, 8);
        border-bottom-color: rgb(55, 50, 50);
-     }
+      }
+     /* RESPONSIVE CSS
+     -------------------------------------------------- */
+
+      @media (min-width: 40em) {
+          /* Bump up size of carousel content */
+          .carousel-caption p {
+              margin-bottom: 1.25rem;
+              font-size: 1.25rem;
+              line-height: 1.4;
+          }
+
+          .featurette-heading {
+              font-size: 50px;
+          }
+      }
+
+      @media (min-width: 62em) {
+          .featurette-heading {
+              margin-top: 7rem;
+          }
+      }
+
+      @media (max-width: 400px) {
+          #foot {
+              font-size: 0.7rem;
+          }
+      }
     </style>
 
 <!-- Custom styles for this template -->
@@ -75,15 +102,15 @@
         <!-- Begin page content -->
          <div id="wrap"
           <div id="main" class="container clear-top">
-              <span><img src="https://www.artspaceoban.co.uk/images/Artspace Oban Logo 1.png" class="img-fluid" alt="Artspace Oban logo"></span>
+              <span><img src="images/Artspace Oban Logo 1.png" class="img-fluid" alt="Artspace Oban logo"></span>
               <p class="display-1">Artspace Oban</p>
               <p class="display-6">studios for artists and makers</p>
           </div>
         </div>
         <footer>
             <div>
-              <nav class="navbar fixed-bottom  nav-masthead justify-content-center float-md-end">
-                <a class="navbar-brand" href="#">Copyright &copy; <script>document.write(new Date().getFullYear())</script> Artspace Oban, All rights reserved - </a>
+              <nav class="navbar fixed-bottom  nav-masthead justify-content-center">
+                <a id="foot" class="navbar-brand" href="#">Copyright &copy; <script>document.write(new Date().getFullYear())</script> Artspace Oban, All rights reserved - </a>
                 <a class="nav-link py-1 px-0 active" href="mailto:artspaceoban@gmail.com?Subject=Contact%20from%20artspace%20Oban&Body=Hello Artspace Oban">Contact</a>
               </nav>
             </div>
@@ -91,5 +118,6 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
 
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Image links should be relative to the current path so in this case index.html can get images directly from `images/*`. Have also fixed the overflow in the footer navbar on mobile however, there is proabably a better solution than this quick fix.